### PR TITLE
refactor(date picker): Migrate to Ant Design 5

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -147,6 +147,7 @@
         "yargs": "^17.7.2"
       },
       "devDependencies": {
+        "@ant-design/moment-webpack-plugin": "^1.0.0",
         "@applitools/eyes-storybook": "^3.50.9",
         "@babel/cli": "^7.22.6",
         "@babel/compat-data": "^7.22.6",
@@ -380,6 +381,13 @@
     },
     "node_modules/@ant-design/icons-svg": {
       "version": "4.4.2",
+      "license": "MIT"
+    },
+    "node_modules/@ant-design/moment-webpack-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/moment-webpack-plugin/-/moment-webpack-plugin-1.0.0.tgz",
+      "integrity": "sha512-t+0PDB312A8XpNklaYyJcaJ2bO0mWWmPQ0U9myKGqZhRWLH0ZTUEbROoYi1N0fSwYnIWuaLa2wYWtH1j/jwJow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ant-design/react-slick": {
@@ -16573,6 +16581,45 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/antd-v5/node_modules/rc-picker": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.5.0.tgz",
+      "integrity": "sha512-suqz9bzuhBQlf7u+bZd1bJLPzhXpk12w6AjQ9BTPTiFwexVZgUKViG1KNLyfFvW6tCUZZK0HmCCX7JAyM+JnCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "^2.2.1",
+        "rc-overflow": "^1.3.2",
+        "rc-resize-observer": "^1.4.0",
+        "rc-util": "^5.38.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "date-fns": ">= 2.x",
+        "dayjs": ">= 1.x",
+        "luxon": ">= 3.x",
+        "moment": ">= 2.x",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "date-fns": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        }
       }
     },
     "node_modules/antd-v5/node_modules/rc-progress": {
@@ -45437,57 +45484,6 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/rc-picker": {
-      "version": "4.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.2.1",
-        "rc-overflow": "^1.3.2",
-        "rc-resize-observer": "^1.4.0",
-        "rc-util": "^5.38.1"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "date-fns": ">= 2.x",
-        "dayjs": ">= 1.x",
-        "luxon": ">= 3.x",
-        "moment": ">= 2.x",
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      },
-      "peerDependenciesMeta": {
-        "date-fns": {
-          "optional": true
-        },
-        "dayjs": {
-          "optional": true
-        },
-        "luxon": {
-          "optional": true
-        },
-        "moment": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/rc-picker/node_modules/rc-resize-observer": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.7",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.38.0",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
     "node_modules/rc-progress": {
       "version": "3.1.1",
       "license": "MIT",
@@ -58837,6 +58833,12 @@
     },
     "@ant-design/icons-svg": {
       "version": "4.4.2"
+    },
+    "@ant-design/moment-webpack-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/moment-webpack-plugin/-/moment-webpack-plugin-1.0.0.tgz",
+      "integrity": "sha512-t+0PDB312A8XpNklaYyJcaJ2bO0mWWmPQ0U9myKGqZhRWLH0ZTUEbROoYi1N0fSwYnIWuaLa2wYWtH1j/jwJow==",
+      "dev": true
     },
     "@ant-design/react-slick": {
       "version": "1.1.2",
@@ -72330,6 +72332,19 @@
             "@babel/runtime": "^7.10.1",
             "classnames": "^2.3.2",
             "rc-util": "^5.38.0"
+          }
+        },
+        "rc-picker": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.5.0.tgz",
+          "integrity": "sha512-suqz9bzuhBQlf7u+bZd1bJLPzhXpk12w6AjQ9BTPTiFwexVZgUKViG1KNLyfFvW6tCUZZK0HmCCX7JAyM+JnCg==",
+          "requires": {
+            "@babel/runtime": "^7.10.1",
+            "@rc-component/trigger": "^2.0.0",
+            "classnames": "^2.2.1",
+            "rc-overflow": "^1.3.2",
+            "rc-resize-observer": "^1.4.0",
+            "rc-util": "^5.38.1"
           }
         },
         "rc-progress": {
@@ -90470,28 +90485,6 @@
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1"
-      }
-    },
-    "rc-picker": {
-      "version": "4.5.0",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.2.1",
-        "rc-overflow": "^1.3.2",
-        "rc-resize-observer": "^1.4.0",
-        "rc-util": "^5.38.1"
-      },
-      "dependencies": {
-        "rc-resize-observer": {
-          "version": "1.4.0",
-          "requires": {
-            "@babel/runtime": "^7.20.7",
-            "classnames": "^2.2.1",
-            "rc-util": "^5.38.0",
-            "resize-observer-polyfill": "^1.5.1"
-          }
-        }
       }
     },
     "rc-progress": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -213,6 +213,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
+    "@ant-design/moment-webpack-plugin": "^1.0.0",
     "@applitools/eyes-storybook": "^3.50.9",
     "@babel/cli": "^7.22.6",
     "@babel/compat-data": "^7.22.6",
@@ -382,5 +383,6 @@
   "scarfSettings": {
     "allowTopLevel": true
   },
-  "_id": "superset@0.0.0-dev"
+  "_id": "superset@0.0.0-dev",
+  "packageManager": "pnpm@9.11.0+sha512.0a203ffaed5a3f63242cd064c8fb5892366c103e328079318f78062f24ea8c9d50bc6a47aa3567cabefd824d170e78fa2745ed1f16b132e16436146b7688f19b"
 }

--- a/superset-frontend/src/components/DatePicker/DatePicker.stories.tsx
+++ b/superset-frontend/src/components/DatePicker/DatePicker.stories.tsx
@@ -16,8 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { DatePickerProps, RangePickerProps } from 'antd/lib/date-picker';
-import { DatePicker, RangePicker } from '.';
+import { DatePicker, RangePicker, RangePickerProps, DatePickerProps } from '.';
 
 export default {
   title: 'DatePicker',
@@ -29,10 +28,12 @@ const commonArgs = {
   autoFocus: true,
   bordered: true,
   disabled: false,
+  order: true,
   inputReadOnly: false,
   size: 'middle',
   format: 'YYYY-MM-DD hh:mm a',
   showTime: { format: 'hh:mm a' },
+  placement: 'bottomLeft',
 };
 
 const interactiveTypes = {
@@ -48,6 +49,25 @@ const interactiveTypes = {
       type: 'select',
     },
     options: ['large', 'middle', 'small'],
+  },
+  placement: {
+    control: {
+      type: 'select',
+    },
+    options: ['bottomLeft', 'bottomRight', 'topLeft', 'topRight'],
+  },
+  status: {
+    control: {
+      type: 'select',
+    },
+    options: ['error', 'warning'],
+  },
+
+  variant: {
+    control: {
+      type: 'select',
+    },
+    options: ['outlined', 'borderless', 'filled'],
   },
 };
 

--- a/superset-frontend/src/components/DatePicker/DatePicker.test.tsx
+++ b/superset-frontend/src/components/DatePicker/DatePicker.test.tsx
@@ -16,25 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { DatePicker as AntdDatePicker } from 'antd-v5';
-// import { RangePickerProps } from 'antd-v5/es/date-picker';
-import {
-  RangePickerProps as BaseRangePickerProps,
-  PickerProps,
-} from 'antd-v5/es/date-picker/generatePicker/interface';
-import { Moment } from 'moment';
-import momentGenerateConfig from 'antd-v5/node_modules/rc-picker/lib/generate/moment';
 
-export type DatePickerProps = PickerProps<Moment>;
+import { render } from 'spec/helpers/testing-library';
+import { DatePicker, RangePicker } from '.';
 
-export type RangePickerProps = BaseRangePickerProps<Moment>;
+test('should render date picker', () => {
+  const { container } = render(<DatePicker />);
+  expect(container).toBeInTheDocument();
+});
 
-export const DatePicker = AntdDatePicker.generatePicker<Moment>(
-  momentGenerateConfig,
-) as React.FC<DatePickerProps>;
-
-export const { RangePicker } = AntdDatePicker.generatePicker<Moment>(
-  momentGenerateConfig,
-) as {
-  RangePicker: React.FC<RangePickerProps>;
-};
+test('should render range picker', () => {
+  const { container } = render(<RangePicker />);
+  expect(container).toBeInTheDocument();
+});

--- a/superset-frontend/src/components/ListView/Filters/DateRange.tsx
+++ b/superset-frontend/src/components/ListView/Filters/DateRange.tsx
@@ -69,7 +69,7 @@ function DateRangeFilter(
         placeholder={[t('Start date'), t('End date')]}
         showTime
         value={momentValue}
-        onChange={momentRange => {
+        onChange={(momentRange: [Moment, Moment]) => {
           if (!momentRange) {
             setValue(null);
             onSubmit([]);

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx
@@ -166,7 +166,7 @@ export function CustomFrame(props: FrameComponentProps) {
                 }
                 allowClear={false}
                 locale={datePickerLocale}
-                getPopupContainer={triggerNode =>
+                getPopupContainer={(triggerNode: HTMLElement) =>
                   props.isOverflowingFilterBar
                     ? (triggerNode.parentNode as HTMLElement)
                     : document.body
@@ -224,7 +224,7 @@ export function CustomFrame(props: FrameComponentProps) {
                 }
                 allowClear={false}
                 locale={datePickerLocale}
-                getPopupContainer={triggerNode =>
+                getPopupContainer={(triggerNode: HTMLElement) =>
                   props.isOverflowingFilterBar
                     ? (triggerNode.parentNode as HTMLElement)
                     : document.body
@@ -287,7 +287,7 @@ export function CustomFrame(props: FrameComponentProps) {
                   allowClear={false}
                   className="control-anchor-to-datetime"
                   locale={datePickerLocale}
-                  getPopupContainer={triggerNode =>
+                  getPopupContainer={(triggerNode: HTMLElement) =>
                     props.isOverflowingFilterBar
                       ? (triggerNode.parentNode as HTMLElement)
                       : document.body

--- a/superset-frontend/src/theme/index.ts
+++ b/superset-frontend/src/theme/index.ts
@@ -67,6 +67,11 @@ const baseConfig: ThemeConfig = {
       paddingLG: supersetTheme.gridUnit * 6,
       fontWeightStrong: supersetTheme.typography.weights.medium,
     },
+    DatePicker: {
+      colorBgContainer: supersetTheme.colors.grayscale.light5,
+      colorBgElevated: supersetTheme.colors.grayscale.light5,
+      borderRadiusSM: supersetTheme.gridUnit / 2,
+    },
     Input: {
       colorBorder: supersetTheme.colors.secondary.light3,
       colorBgContainer: supersetTheme.colors.grayscale.light5,

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -32,6 +32,7 @@ const {
   getCompilerHooks,
 } = require('webpack-manifest-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const AntdMomentWebpackPlugin = require('@ant-design/moment-webpack-plugin');
 const parsedArgs = require('yargs').argv;
 const Visualizer = require('webpack-visualizer-plugin2');
 const getProxyConfig = require('./webpack.proxy-config');
@@ -92,6 +93,8 @@ if (!isDevMode) {
 }
 
 const plugins = [
+  new AntdMomentWebpackPlugin(),
+
   new webpack.ProvidePlugin({
     process: 'process/browser.js',
     ...(isDevMode ? { Buffer: ['buffer', 'Buffer'] } : {}), // Fix legacy-plugin-chart-paired-t-test broken Story


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Migrate Datepicker to Ant Design 5 while keeping visual consistency. This might require moving to DayJs as Ant Design 5 uses DayJs.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
